### PR TITLE
フリマアプリ挙動確認修正#1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,15 @@
 class ApplicationController < ActionController::Base
   # before_action :authenticate_user!  ログインしてない時遷移する。
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -55,6 +55,6 @@ class ItemsController < ApplicationController
 
   def move_to_index
     item = Item.find(params[:id])
-    redirect_to action: :index unless current_user == item.user
+    redirect_to action: :index if current_user != item.user || item.transaction_item.presence
   end
 end


### PR DESCRIPTION
# WHAT
フリアマプリ挙動確認後　修正
出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
# WHY
URLを直接入力すると売却済み商品の商品情報編集ページへ遷移できる挙動の修正
